### PR TITLE
[WIP] Windows and Darwin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,16 @@
 Provides a clock that returns nondecreasing values and is not affected
 by (user-adjustable) system time.
 
-## [Function] monotonic-now &optional mode
+## [Function] monotonic-now &optional mode include-suspend-p
 
 Return the current monotonic time in monotonic time units.
 
 If `mode` is `nil` (the default) the monotonic time is possibly
 affected by NTP.  If it is `:raw`, effort is made to return a
 monotonic time that is not affected by NTP.
+
+If `include-suspend-p` is true, time spent while the system is suspended is
+included. The default is platform dependent.
 
 ## [Function] monotonic-time-units-per-second
 
@@ -18,7 +21,7 @@ Return the number of monotonic time units in one second.
 The value returned should remain valid for the duration of the running
 Lisp process, but no guarantee is made beyond this extent.
 
-## [Function] monotonic-now/ms &optional mode
+## [Function] monotonic-now/ms &optional mode include-suspend-p
 
 A convenience function to return the current monotonic time in
 milliseconds.

--- a/darwin-grovel.lisp
+++ b/darwin-grovel.lisp
@@ -1,0 +1,4 @@
+(in-package #:monotonic-clock)
+
+(include "mach.h")
+(include "mach/mach_time.h")

--- a/darwin.lisp
+++ b/darwin.lisp
@@ -1,0 +1,36 @@
+(in-package #:monotonic-clock)
+
+;; https://developer.apple.com/library/content/qa/qa1398/_index.html
+
+(defcfun ("mach_absolute_time" mach-absolute-time) :uint64)
+
+(defcstruct mach-timebase-info
+  (numer :uint32)
+  (denom :uint32))
+
+(defcfun ("mach_timebase_info" mach-timebase-info) :void
+  (timebase-info :pointer))
+
+(declaim (inline monotonic-time-units-per-second))
+(defun monotonic-time-units-per-second ()
+  "Return the number of monotonic time units in one second.
+
+The value returned should remain valid for the duration of the running
+Lisp process, but no guarantee is made beyond this extent."
+  (load-time-value
+   (with-foreign-object (ti '(:struct mach-timebase-info))
+     (mach-timebase-info ti)
+     (with-foreign-slots ((numer denom) ti (:struct mach-timebase-info))
+       (truncate (* 1000000000 (/ numer denom)))))))
+
+(defun monotonic-now (&optional mode include-suspend-p)
+  "Return the current monotonic time in monotonic time units.
+
+MODE is ignored. The monotonic time is not affected by NTP.
+
+If INCLUDE-SUSPEND-P is true, time spent while the system is suspended is
+included. The default is false."
+  (declare (ignore mode))
+  (assert (not include-suspend-p) (include-suspend-p)
+          "Does not support INCLUDE-SUSPEND-P = true.")
+  (mach-absolute-time))

--- a/linux.lisp
+++ b/linux.lisp
@@ -29,12 +29,17 @@ The value returned should remain valid for the duration of the running
 Lisp process, but no guarantee is made beyond this extent."
   1000000000)
 
-(defun monotonic-now (&optional mode)
+(defun monotonic-now (&optional mode include-suspend-p)
   "Return the current monotonic time in monotonic time units.
 
 If MODE is NIL (the default) the monotonic time is possibly affected
 by NTP.  If it is :RAW, effort is made to return a monotonic time that
-is not affected by NTP."
+is not affected by NTP.
+
+If INCLUDE-SUSPEND-P is true, time spent while the system is suspended is
+included. The default is false."
+  (assert (not include-suspend-p) (include-suspend-p)
+          "Does not support INCLUDE-SUSPEND-P = true.")
   (multiple-value-bind (sec nsec)
       (clock-gettime (ecase mode
                        ((nil) clock-monotonic)

--- a/monotonic-clock.asd
+++ b/monotonic-clock.asd
@@ -6,11 +6,15 @@
   :description "A nondecreasing clock that is not affected by user settings."
   :author "death <github.com/death>"
   :license "MIT"
-  :defsystem-depends-on (#+linux #:cffi-grovel)
+  :defsystem-depends-on (#+(linux darwin windows) #:cffi-grovel)
   :depends-on (#:cffi)
   :serial t
   :components
   ((:file "packages")
    #+linux (:cffi-grovel-file "linux-grovel")
    #+linux (:file "linux")
+   #+darwin (:cffi-grovel-file "darwin-grovel")
+   #+darwin (:file "darwin")
+   #+windows (:cffi-grovel-file "windows-grovel")
+   #+windows (:file "windows")
    (:file "convenience")))

--- a/monotonic-clock.asd
+++ b/monotonic-clock.asd
@@ -6,7 +6,7 @@
   :description "A nondecreasing clock that is not affected by user settings."
   :author "death <github.com/death>"
   :license "MIT"
-  :defsystem-depends-on (#+(linux darwin windows) #:cffi-grovel)
+  :defsystem-depends-on (#+(or linux darwin windows) #:cffi-grovel)
   :depends-on (#:cffi)
   :serial t
   :components

--- a/windows-grovel.lisp
+++ b/windows-grovel.lisp
@@ -1,0 +1,3 @@
+(in-package #:monotonic-clock)
+
+(include "Windows.h")

--- a/windows.lisp
+++ b/windows.lisp
@@ -1,0 +1,25 @@
+(in-package #:monotonic-clock)
+
+;; https://msdn.microsoft.com/en-us/library/windows/desktop/ms724411%28v=vs.85%29.aspx
+
+(defcfun ("GetTickCount64" get-tick-count-64) :uint64)
+
+(declaim (inline monotonic-time-units-per-second))
+(defun monotonic-time-units-per-second ()
+  "Return the number of monotonic time units in one second.
+
+The value returned should remain valid for the duration of the running
+Lisp process, but no guarantee is made beyond this extent."
+  1000)
+
+(defun monotonic-now (&optional mode (include-suspend-p t))
+  "Return the current monotonic time in monotonic time units.
+
+MODE is ignored. The monotonic time is not affected by NTP.
+
+If INCLUDE-SUSPEND-P is true, time spent while the system is suspended is
+included. The default is true."
+  (declare (ignore mode))
+  (assert include-suspend-p (include-suspend-p)
+          "Does not support INCLUDE-SUSPEND-P = false.")
+  (get-tick-count-64))


### PR DESCRIPTION
Sketch for Windows and Darwin support. I haven’t actually tested this since I do not own a Mac or Windows license. This is basically https://github.com/Clozure/ccl/pull/46 translated to this library.

See: https://www.python.org/dev/peps/pep-0418/#monotonic-clocks
For Windows: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724411%28v=vs.85%29.aspx
For Darwin: https://developer.apple.com/library/content/qa/qa1398/_index.html

This adds a new optional parameter, INCLUDE-SUSPEND-P that reflects how
the different platform specific clocks handle system suspension.